### PR TITLE
Feat/#20 외국인 번호 및 비자 발급 일자 등록 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3002,7 +3002,7 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.16",
@@ -3020,7 +3020,7 @@
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
       "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"

--- a/src/features/layout/Header/index.tsx
+++ b/src/features/layout/Header/index.tsx
@@ -1,34 +1,48 @@
 import styled from '@emotion/styled';
-import LogoImg from '@/assets/images/hirehigher-logo.svg';
+import LogoImg from '@assets/images/hirehigher-logo.svg?react';
+import Button from '@components/common/Button';
+import { Flex } from '@/components/common';
+import { css } from '@emotion/react';
 
-const Header = () => {
+export default function Header() {
   return (
     <HeaderContainer>
-      <Logo src={LogoImg} alt="Hire Higher" />
-      <Nav>
-        <Dropdown>
-          <option value="none">언어</option>
-          <option value="kr">한국어</option>
-        </Dropdown>
-        <OutlinedButton>채용공고 등록</OutlinedButton>
-        <TextButton>닉네임</TextButton>
-        <PrimaryButton>로그아웃</PrimaryButton>
-      </Nav>
+      <StyledFlex>
+        <LogoImg />
+        <Nav>
+          <Dropdown>
+            <option value="none">언어</option>
+            <option value="kr">한국어</option>
+          </Dropdown>
+          <Button theme="outlined" css={[commonButtonStyles]}>
+            채용공고 등록
+          </Button>
+          <Button theme="textbutton" css={[commonButtonStyles]}>
+            닉네임
+          </Button>
+          <Button
+            css={[
+              commonButtonStyles,
+              css`
+                background-color: #0a65cc;
+                color: #fff;
+              `,
+            ]}
+          >
+            로그아웃
+          </Button>
+        </Nav>
+      </StyledFlex>
     </HeaderContainer>
   );
-};
+}
 
 const HeaderContainer = styled.header`
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
-  padding: 0 20px;
   background-color: #fff;
   height: 88px;
-
-  @media (max-width: 1200px) {
-    padding: 0 15px;
-  }
 
   @media (max-width: 768px) {
     flex-direction: column;
@@ -42,16 +56,14 @@ const HeaderContainer = styled.header`
   }
 `;
 
-const Logo = styled.img`
-  height: 70px;
-  width: auto;
+const StyledFlex = styled(Flex)`
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  max-width: 1300px;
 
   @media (max-width: 768px) {
-    height: 60px;
-  }
-
-  @media (max-width: 480px) {
-    height: 50px;
+    flex-direction: column;
   }
 `;
 
@@ -73,59 +85,16 @@ const Nav = styled.nav`
   }
 `;
 
-const ButtonStyle = styled.button`
-  padding: 10px 20px;
-  width: 100%;
-  background-color: #fff;
-  color: #0a65cc;
-  border: 1px solid #cee0f5;
-  border-radius: 3px;
-  cursor: pointer;
-  text-align: center;
-  white-space: nowrap;
-  font-size: 16px;
-
-  @media (max-width: 768px) {
-    font-size: 15px;
-  }
-
-  @media (max-width: 480px) {
-    padding: 8px 10px;
-    font-size: 14px;
-  }
-`;
-
-const PrimaryButton = styled(ButtonStyle)`
-  background-color: #0a65cc;
-  color: #fff;
-  border: none;
-`;
-
-const OutlinedButton = styled(ButtonStyle)``;
-
-const TextButton = styled(ButtonStyle)`
-  background-color: none;
-  border: none;
-`;
-
 const Dropdown = styled.select`
   padding: 10px 20px;
-  width: 100%;
   color: #0a65cc;
   cursor: pointer;
   text-align: center;
   font-size: 16px;
   border: none;
-
-  @media (max-width: 768px) {
-    padding: 8px 10px;
-    font-size: 15px;
-  }
-
-  @media (max-width: 480px) {
-    margin-top: 10px;
-    font-size: 14px;
-  }
 `;
 
-export default Header;
+const commonButtonStyles = css`
+  white-space: nowrap;
+  border-radius: 4px;
+`;

--- a/src/pages/visaRegistration/index.stories.tsx
+++ b/src/pages/visaRegistration/index.stories.tsx
@@ -1,0 +1,25 @@
+import { Meta, StoryObj } from '@storybook/react';
+import VisaRegistration from '.';
+import { ThemeProvider } from '@emotion/react';
+import theme from '@/assets/styles/theme';
+
+const meta: Meta<typeof VisaRegistration> = {
+  title: 'pages/VisaRegistration',
+  component: VisaRegistration,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => {
+      return (
+        <ThemeProvider theme={theme}>
+          <Story />
+        </ThemeProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof VisaRegistration>;
+
+export const Default: Story = {};

--- a/src/pages/visaRegistration/index.tsx
+++ b/src/pages/visaRegistration/index.tsx
@@ -90,7 +90,18 @@ const Form = styled.form`
   gap: 40px;
   font-size: 16px;
   font-weight: bold;
-  width: 700px;
+  width: 100%;
+  max-width: 700px;
+  margin: 0 auto;
+
+  @media (max-width: 768px) {
+    gap: 20px;
+    padding: 0 20px;
+  }
+
+  @media (max-width: 480px) {
+    padding: 0 15px;
+  }
 `;
 
 const InputWrapper = styled.div`

--- a/src/pages/visaRegistration/index.tsx
+++ b/src/pages/visaRegistration/index.tsx
@@ -1,0 +1,111 @@
+import { Button, Flex, InnerContainer, Input, Typo } from '@/components/common';
+import Footer from '@/features/layout/footer';
+import Header from '@/features/layout/Header';
+import styled from '@emotion/styled';
+import { ChangeEvent, useState } from 'react';
+
+export default function VisaRegistration() {
+  const [foreignerNumber, setForeignerNumber] = useState('');
+  const [visaGenerateDate, setVisaGenerateDate] = useState('');
+  const [error, setError] = useState('');
+
+  const validateForeignerNumber = (number: string) => {
+    const regex = /^\d{6}-\d{7}$/;
+    return regex.test(number);
+  };
+
+  const handleForeignerNumberChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    if (!validateForeignerNumber(value) && value !== '') {
+      setError('올바른 형식으로 입력해주세요. 형식: 000000-0000000');
+    } else {
+      setError('');
+    }
+    setForeignerNumber(value);
+  };
+
+  const handleSubmit = async () => {
+    if (!validateForeignerNumber(foreignerNumber)) {
+      alert('외국인 번호를 올바른 형식으로 입력해주세요.');
+      return;
+    }
+    alert('외국인 번호 및 비자 발급 일자 등록이 완료되었습니다.');
+  };
+
+  return (
+    <>
+      <Header />
+      <MainContainer>
+        <InnerContainer
+          maxWidth="1300px"
+          style={{ height: '520px', padding: '50px 0', border: '1px solid #E9E9E9', borderRadius: '12px' }}
+        >
+          <Flex justifyContent="center" alignItems="center" direction="column" style={{ height: '100%' }}>
+            <Typo element="h2" size="24px" style={{ marginBottom: '60px' }}>
+              외국인 번호 및 발급 일자 등록
+            </Typo>
+            <Form onSubmit={handleSubmit}>
+              <InputWrapper>
+                <Input
+                  label="외국인 번호"
+                  type="text"
+                  value={foreignerNumber}
+                  onChange={handleForeignerNumberChange}
+                  style={{ padding: '15px 20px' }}
+                  required
+                />
+                {error && <ErrorMessage>{error}</ErrorMessage>}
+              </InputWrapper>
+              <InputWrapper>
+                <Input
+                  label="비자 발급 일자"
+                  type="date"
+                  value={visaGenerateDate}
+                  onChange={(e) => setVisaGenerateDate(e.target.value)}
+                  style={{ padding: '15px 20px' }}
+                  required
+                />
+              </InputWrapper>
+              <ButtonContainer>
+                <Button type="submit" style={{ backgroundColor: '#0A65CC', color: '#fff', borderRadius: '4px' }}>
+                  등록하기
+                </Button>
+              </ButtonContainer>
+            </Form>
+          </Flex>
+        </InnerContainer>
+      </MainContainer>
+      <Footer />
+    </>
+  );
+}
+
+const MainContainer = styled.div`
+  padding: 40px 0;
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  font-size: 16px;
+  font-weight: bold;
+  width: 700px;
+`;
+
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const ButtonContainer = styled.div`
+  width: auto;
+  display: flex;
+  justify-content: center;
+`;
+
+const ErrorMessage = styled.div`
+  color: red;
+  font-size: 13px;
+`;

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -1,4 +1,5 @@
 export const ROUTE_PATH = {
   HOME: '/',
   SIGN_IN: '/sign-in',
+  VISA_REGISTRATION: '/visa-registration',
 };

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -2,11 +2,15 @@ import { createBrowserRouter } from 'react-router-dom';
 import { ROUTE_PATH } from './path';
 import App from '@/App';
 import SignIn from '@/pages/auth/SignIn';
+import VisaRegistration from '@/pages/visaRegistration';
 
 export const router = createBrowserRouter([
   {
     path: ROUTE_PATH.HOME,
     element: <App />,
-    children: [{ path: ROUTE_PATH.SIGN_IN, element: <SignIn /> }],
+    children: [
+      { path: ROUTE_PATH.SIGN_IN, element: <SignIn /> },
+      { path: ROUTE_PATH.VISA_REGISTRATION, element: <VisaRegistration /> },
+    ],
   },
 ]);


### PR DESCRIPTION
## Issue
#20 

## Description
## 외국인 번호 등록 및 비자 발급 일자 페이지 구현
### 유효하지 않은 입력 발생 시 안내 메시지 표시
<img src="https://github.com/user-attachments/assets/08969977-26dd-4ba7-9ada-d34461991dbd" width="500px" />

`000000-0000000` 형식의 숫자 입력이 아니면 위의 이미지와 같이 올바른 입력을 요구하는 안내 메시지가 표시되도록 하였습니다. 

### 등록 완료 알림
올바른 형식의 외국인 번호와 비자 발급 일자를 입력한 후 `등록하기` 버튼을 누르면 등록 완료 alert창이 나타나도록 해두었습니다.

## Header 컴포넌트 수정
- nav의 버튼들을 공통 컴포넌트로 변경
- `max-width: 1300px` 적용

  |변경 전|
  |:---:|
  |<img src="https://github.com/user-attachments/assets/bd7ee6e4-7d06-46b3-b658-1762449c60db" width="500px" />|

  |변경 후|
  |:---:|
  |<img src="https://github.com/user-attachments/assets/817508e9-67e2-4414-b867-8599d99e6e9b" width="500px" />|

## Review Requirements
`Header` 컴포넌트에서 다른 theme을 가진 버튼들에 공통된 스타일을 적용하면서, 특정 버튼에만 추가적인 스타일을 주는 작업을 했습니다. 아래와 같이 각 버튼에 공통적으로 적용될 스타일을 `commonButtonStyles`로 정의하고, `theme=default`인 버튼에만 추가 스타일을 적용해보았는데, 제가 구현한 방식보다 더 괜찮은 방법이 있는지 궁금합니다.
```typescript
const commonButtonStyles = css`
  white-space: nowrap;
  border-radius: 4px;
`;
```
```html
<Button theme="outlined" css={[commonButtonStyles]}>
  채용공고 등록
</Button>
<Button theme="textbutton" css={[commonButtonStyles]}>
   닉네임
</Button>
<Button
  css={[
    commonButtonStyles,
    css`
      background-color: #0a65cc;
      color: #fff;
    `,
   ]}
>
  로그아웃
</Button>
```