### PR TITLE
Feat/#58 OAuth 구글 로그인 구현

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,3 @@
-VITE_BASE_URL=http://localhost:8080
+VITE_BASE_URL=http://localhost:5173
+VITE_GOOGLE_AUTH_CLIENT_ID=268837811477-28b8i24r1sb0aroltho84ia6jecj74h7.apps.googleusercontent.com
+VITE_GOOGLE_AUTH_REDIRECT_URI=http://localhost:5173/loading

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import type { Preview } from '@storybook/react';
 import AppProviders from '../src/components/providers/index.provider';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { handlers } from '../src/mocks/handlers';
+import { MemoryRouter } from 'react-router-dom';
 
 initialize();
 
@@ -21,9 +22,11 @@ const preview: Preview = {
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <AppProviders>
-        <Story />
-      </AppProviders>
+      <MemoryRouter>
+        <AppProviders>
+          <Story />
+        </AppProviders>
+      </MemoryRouter>
     ),
   ],
   loaders: [mswLoader],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@loadable/component": "^5.16.4",
+        "@react-oauth/google": "^0.12.1",
         "@tanstack/react-query": "^5.56.2",
         "axios": "^1.7.7",
         "csstype": "^3.1.3",
@@ -1466,6 +1467,15 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.1.tgz",
+      "integrity": "sha512-qagsy22t+7UdkYAiT5ZhfM4StXi9PPNvw0zuwNmabrWyMKddczMtBIOARflbaIj+wHiQjnMAsZmzsUYuXeyoSg==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.19.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@loadable/component": "^5.16.4",
+    "@react-oauth/google": "^0.12.1",
     "@tanstack/react-query": "^5.56.2",
     "axios": "^1.7.7",
     "csstype": "^3.1.3",

--- a/src/apis/auth/mutations/useGoogleOAuth.tsx
+++ b/src/apis/auth/mutations/useGoogleOAuth.tsx
@@ -1,0 +1,81 @@
+import { clientInstance } from '@apis/instance';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { AUTH_PATH } from '../path';
+import { OAuthRequest } from '../types/request';
+import { OAuthResponse } from '../types/response';
+import { useNavigate } from 'react-router-dom';
+import { useCallback, useState, useEffect } from 'react';
+import ROUTE_PATH from '@/routes/path';
+
+const clientId = import.meta.env.VITE_GOOGLE_AUTH_CLIENT_ID;
+const redirectUri = import.meta.env.VITE_GOOGLE_AUTH_REDIRECT_URI;
+
+const getAccessTokenFromUrl = () => {
+  const hashParams = new URLSearchParams(window.location.hash.substring(1));
+  return hashParams.get('access_token');
+};
+
+const postOAuth = async ({ token }: OAuthRequest): Promise<OAuthResponse> => {
+  const res = await clientInstance.post(AUTH_PATH.OAUTH, { token });
+
+  const accessToken = res.headers['authorization'];
+  if (!accessToken) {
+    throw new Error('Authorization header is missing in the response');
+  }
+
+  return {
+    accessToken,
+    type: res.data.type,
+    profileImage: res.data.profileImage,
+  };
+};
+
+export function useGoogleOAuth(): {
+  isLoading: boolean;
+  redirectToGoogleLogin: () => void;
+} {
+  const [isLoading, setIsLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const redirectToGoogleLogin = useCallback(() => {
+    const googleAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?scope=https%3A//www.googleapis.com/auth/drive.metadata.readonly&include_granted_scopes=true&response_type=token&state=state_parameter_passthrough_value&redirect_uri=${redirectUri}&client_id=${clientId}`;
+
+    window.location.href = googleAuthUrl;
+  }, []);
+
+  const { mutate: handleLoginPost, status } = useMutation<OAuthResponse, AxiosError, OAuthRequest>({
+    mutationFn: postOAuth,
+    onSuccess: (data) => {
+      const { accessToken, type } = data;
+
+      localStorage.setItem('token', accessToken);
+
+      if (type === 'first') {
+        navigate(ROUTE_PATH.AUTH.SIGN_UP);
+      } else {
+        navigate(ROUTE_PATH.HOME);
+      }
+
+      window.location.reload();
+    },
+    onError: (error) => {
+      console.error('Error during login:', error);
+      setIsLoading(false);
+    },
+  });
+
+  const isMutating = status === 'pending';
+
+  useEffect(() => {
+    const token = getAccessTokenFromUrl();
+    if (token) {
+      setIsLoading(true);
+      handleLoginPost({ token });
+    } else {
+      console.log('로그인 재시도하세요.');
+    }
+  }, [handleLoginPost]);
+
+  return { isLoading: isLoading || isMutating, redirectToGoogleLogin };
+}

--- a/src/apis/auth/path.ts
+++ b/src/apis/auth/path.ts
@@ -1,0 +1,5 @@
+const BASE_URL = '/api';
+
+export const AUTH_PATH = {
+  OAUTH: `${BASE_URL}/oauth`,
+};

--- a/src/apis/auth/types/request.ts
+++ b/src/apis/auth/types/request.ts
@@ -1,0 +1,3 @@
+export interface OAuthRequest {
+  token: string;
+}

--- a/src/apis/auth/types/response.ts
+++ b/src/apis/auth/types/response.ts
@@ -1,0 +1,5 @@
+export interface OAuthResponse {
+  accessToken: string;
+  type: 'first' | 'employee' | 'employer';
+  profileImage: string;
+}

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
 import { QueryClient } from '@tanstack/react-query';
 
-const BASE_URL = import.meta.env.BASE_URL;
+const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 const setInterceptors = (instance: AxiosInstance) => {
   instance.interceptors.response.use(

--- a/src/features/auth/SignIn/components/SignInButton.tsx
+++ b/src/features/auth/SignIn/components/SignInButton.tsx
@@ -1,11 +1,14 @@
+import { useGoogleOAuth } from '@/apis/auth/mutations/useGoogleOAuth';
 import { Flex, Typo, Button, Icon } from '@components/common';
 
 const FLEX_GAP_CONFIG = { x: '12px' };
 const BUTTON_STYLE = { fontWeight: '300' };
 
 export function SignInButton() {
+  const { redirectToGoogleLogin } = useGoogleOAuth();
+
   return (
-    <Button theme="outlined">
+    <Button theme="outlined" onClick={redirectToGoogleLogin}>
       <Flex alignItems="center" gap={FLEX_GAP_CONFIG}>
         <Icon.Social.Google />
         <Typo size="14px" color="gray" element="span" style={BUTTON_STYLE}>

--- a/src/pages/auth/Loading/index.tsx
+++ b/src/pages/auth/Loading/index.tsx
@@ -1,0 +1,18 @@
+import { Spinner, Typo } from '@/components/common';
+import { useGoogleOAuth } from '@/apis/auth/mutations/useGoogleOAuth';
+
+export default function LoadingPage() {
+  const { isLoading } = useGoogleOAuth();
+
+  return (
+    <div>
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        <Typo element="h1" size="18px" bold color="blue">
+          로그인 처리 중 오류가 발생했습니다.
+        </Typo>
+      )}
+    </div>
+  );
+}

--- a/src/routes/path.ts
+++ b/src/routes/path.ts
@@ -1,6 +1,7 @@
 export const AUTH = {
   SIGN_IN: '/sign-in',
   SIGN_UP: '/sign-up',
+  LOADING: '/loading',
 } as const;
 
 export const APPLY = {

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import ROUTE_PATH from './path';
 import SignIn from '@pages/auth/SignIn';
 import SignUp from '@pages/auth/SignUp';
+import LoadingPage from '@/pages/auth/Loading';
 import App from '@/App';
 import Recruit from '@/pages/recruit';
 import VisaRegistration from '@/pages/employee/visaRegistration';
@@ -22,6 +23,10 @@ export const router = createBrowserRouter([
       {
         path: ROUTE_PATH.AUTH.SIGN_UP,
         element: <SignUp />,
+      },
+      {
+        path: ROUTE_PATH.AUTH.LOADING,
+        element: <LoadingPage />,
       },
       { path: ROUTE_PATH.RECRUIT, element: <Recruit /> },
       { path: ROUTE_PATH.POST_NOTICE, element: <PostNotice /> },


### PR DESCRIPTION
## Issue
> close #58 

## Description
Google OAuth 로그인 플로우를 처리하기 위한 커스텀 훅 `useGoogleOAuth`를 구현했습니다.

Google 로그인 버튼 클릭 시 OAuth 인증 페이지로 리디렉션하고, 로그인 성공 후 서버로 access token을 전송하여 사용자 인증을 처리합니다.

서버 응답에서 `accessToken`은 응답 헤더(`Authorization`)로 받아, 이를 `localStorage`에 저장한 후 적절한 경로로 리디렉션 처리합니다.

<br />

## useGoogleOauth 훅 구현

- **OAuth 리디렉션**
    - `redirectToGoogleLogin` 함수는 Google OAuth 로그인 URL로 사용자를 리디렉션합니다. 필요한 클라이언트 ID와 리디렉션 URI는 환경 변수에서 가져옵니다.
        
        ```tsx
        const clientId = import.meta.env.VITE_GOOGLE_AUTH_CLIENT_ID;
        const redirectUri = import.meta.env.VITE_GOOGLE_AUTH_REDIRECT_URI;
        
        const redirectToGoogleLogin = useCallback(() => {
          const googleAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?scope=https%3A//www.googleapis.com/auth/drive.metadata.readonly&include_granted_scopes=true&response_type=token&state=state_parameter_passthrough_value&redirect_uri=${redirectUri}&client_id=${clientId}`;
        
          window.location.href = googleAuthUrl;
        }, []);
        ```
        
- **accessToken 처리**
    - 리디렉션 후, URL의 해시에서 access token을 추출하고, 이를 서버로 전송하여 사용자 인증을 처리합니다.
        
        ```tsx
        const getAccessTokenFromUrl = () => {
          const hashParams = new URLSearchParams(window.location.hash.substring(1));
          return hashParams.get('access_token');
        };
        
        const postOAuth = async ({ token }: OAuthRequest): Promise<OAuthResponse> => {
          const res = await clientInstance.post(AUTH_PATH.OAUTH, { token });
        
          const accessToken = res.headers['authorization'];
          if (!accessToken) {
            throw new Error('Authorization header is missing in the response');
          }
        
          return {
            accessToken,
            type: res.data.type,
            profileImage: res.data.profileImage,
          };
        };
        ```
        
- **사용자 리다이렉트**
    - 서버 응답에서 헤더로 받은 `accessToken`을 `localStorage`에 저장합니다.
    - 서버 응답에 따라 사용자 유형이 'first'인 경우 회원가입 페이지로, 그 외의 경우 홈 페이지로 리다이렉트됩니다.
        
        ```tsx
        const { mutate: handleLoginPost, status } = useMutation<OAuthResponse, AxiosError, OAuthRequest>({
            mutationFn: postOAuth,
            onSuccess: (data) => {
              const { accessToken, type } = data;
        
              localStorage.setItem('token', accessToken);
        
              if (type === 'first') {
                navigate(ROUTE_PATH.AUTH.SIGN_UP);
              } else {
                navigate(ROUTE_PATH.HOME);
              }
        
              window.location.reload();
            },
            onError: (error) => {
              console.error('Error during login:', error);
              setIsLoading(false);
            },
          });
        ```
        
<br />

## Usage

버튼 클릭시 구글 로그인 팝업으로 이동하기 위해 redirectToGoogleLogin 함수를 호출합니다.

```tsx
import { useGoogleOAuth } from '@/apis/auth/mutations/useGoogleOAuth';

export function SignInButton() {
  const { redirectToGoogleLogin } = useGoogleOAuth();

  return (
    <Button theme="outlined" onClick={redirectToGoogleLogin}>
      <Flex alignItems="center" gap={FLEX_GAP_CONFIG}>
        <Icon.Social.Google />
        <Typo size="14px" color="gray" element="span" style={BUTTON_STYLE}>
          Sign up with Google
        </Typo>
      </Flex>
    </Button>
  );
}
```

이후 사용자가 구글 아이디를 선택하면 `LoadingPage` 로 이동하게 되며 자동으로 서버에 구글 서버에서 받은 accessToken을 전송합니다.

서버에서 응답이오면 가입여부에 따라 자동으로 리다이렉트됩니다.

```tsx
import { Spinner, Typo } from '@/components/common';
import { useGoogleOAuth } from '@/apis/auth/mutations/useGoogleOAuth';

export default function LoadingPage() {
  const { isLoading } = useGoogleOAuth();

  return (
    <div>
      {isLoading ? (
        <Spinner />
      ) : (
        <Typo element="h1" size="18px" bold color="blue">
          로그인 처리 중 오류가 발생했습니다.
        </Typo>
      )}
    </div>
  );
}
```

<br />

## ScreenShots

![Oct-23-2024 13-20-40](https://github.com/user-attachments/assets/71f25ddf-dd6c-451c-9ade-96c8ebdd5cfb)

