### PR TITLE
Feat/#123 마이페이지 접근 제한, 외국인 번호 및 비자 발급 일자 등록 후 페이지 이동 기능 추가

### DIFF
--- a/src/features/registerVisa/VisaRegistrationForm.tsx
+++ b/src/features/registerVisa/VisaRegistrationForm.tsx
@@ -4,6 +4,8 @@ import { useRegisterVisaInfo } from '@/apis/applicants/hooks/useRegisterVisaInfo
 import { buttonStyle, ErrorMessage, Form, inputStyle } from './VisaRegistrationForm.styles';
 import { validateForeignerNumber } from './validateForeignerNumber';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import ROUTE_PATH from '@/routes/path';
 
 export default function VisaRegistrationForm() {
   const [foreignerIdNumber, setForeignerNumber] = useState('');
@@ -11,6 +13,7 @@ export default function VisaRegistrationForm() {
   const [error, setError] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const formValid = useMemo(() => !error, [error]);
+  const navigate = useNavigate();
 
   const registerVisaMutation = useRegisterVisaInfo();
   const { t } = useTranslation();
@@ -44,6 +47,7 @@ export default function VisaRegistrationForm() {
 
   const closeModal = () => {
     setIsModalOpen(false);
+    navigate(ROUTE_PATH.EMPLOYEE.EMPLOYEE_PAGE);
   };
 
   return (

--- a/src/routes/guards/RequireAuth.tsx
+++ b/src/routes/guards/RequireAuth.tsx
@@ -1,0 +1,22 @@
+import { userLocalStorage } from '@/utils/storage';
+import { useNavigate } from 'react-router-dom';
+import ROUTE_PATH from '../path';
+import { ReactNode, useEffect } from 'react';
+
+interface RequireAuthProps {
+  children: ReactNode;
+  expectedType: 'employee' | 'employer';
+}
+
+export function RequireAuth({ children, expectedType }: RequireAuthProps) {
+  const user = userLocalStorage.getUser();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user || user.type !== expectedType) {
+      navigate(ROUTE_PATH.HOME);
+    }
+  }, [user, expectedType, navigate]);
+
+  return user && user.type === expectedType ? children : null;
+}

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -19,6 +19,7 @@ import EmployeeContract from '@/pages/contract/EmployeeContract/EmployeeContract
 import EmployerContract from '@/pages/contract/EmployerContract/EmployerContract';
 import MyCompanyPage from '@/pages/myCompanyPage/MyCompanyPage';
 import ApplicantsPage from '@/pages/applicantsPage/ApplicantsPage';
+import { RequireAuth } from './guards/RequireAuth';
 
 export const router = createBrowserRouter([
   {
@@ -41,12 +42,26 @@ export const router = createBrowserRouter([
       { path: ROUTE_PATH.APPLY.APPLYPAGE, element: <ApplyPage /> },
       { path: ROUTE_PATH.RECRUIT, element: <Recruit /> },
       { path: ROUTE_PATH.REGISTER_VISA, element: <RegisterVisa /> },
-      { path: ROUTE_PATH.EMPLOYEE.EMPLOYEE_PAGE, element: <EmployeeMyPage /> },
+      {
+        path: ROUTE_PATH.EMPLOYEE.EMPLOYEE_PAGE,
+        element: (
+          <RequireAuth expectedType="employee">
+            <EmployeeMyPage />
+          </RequireAuth>
+        ),
+      },
       { path: ROUTE_PATH.POST_NOTICE, element: <PostNotice /> },
       { path: ROUTE_PATH.MY_COMPANY, element: <MyCompanyPage /> },
       { path: ROUTE_PATH.APPLICANTS, element: <ApplicantsPage /> },
       { path: ROUTE_PATH.RESUME, element: <Resume /> },
-      { path: ROUTE_PATH.MY_PAGE.EMPLOYER, element: <EmployerMyPage /> },
+      {
+        path: ROUTE_PATH.MY_PAGE.EMPLOYER,
+        element: (
+          <RequireAuth expectedType="employer">
+            <EmployerMyPage />
+          </RequireAuth>
+        ),
+      },
       { path: ROUTE_PATH.REGISTERSIGN, element: <RegisterSign /> },
       { path: ROUTE_PATH.REGISTERCOMPANY, element: <RegisterCompany /> },
       { path: ROUTE_PATH.CONTRACT.EMPLOYEE, element: <EmployeeContract /> },


### PR DESCRIPTION
## Issue
> #123 

## Description
### 외국인 번호 및 비자 발급 일자 등록 페이지
- **등록 완료 모달**에서 **확인** 버튼을 누르면 **근로자 마이페이지**로 이동합니다.

### 마이페이지 이동
프로필 이미지 클릭을 이용하지 않고 등록된 사용자 타입(employee, employer)과 다른 마이페이지로 직접 이동하려고 하는 경우, 홈으로 이동하도록 하였습니다.
- `src/routes/guards/RequireAuth.tsx`
``` typescript
import { userLocalStorage } from "@/utils/storage";
import { useNavigate } from "react-router-dom";
import ROUTE_PATH from "../path";
import { ReactNode, useEffect } from "react";

interface RequireAuthProps {
  children: ReactNode;
  expectedType: 'employee' | 'employer';
}

export function RequireAuth({ children, expectedType }: RequireAuthProps) {
  const user = userLocalStorage.getUser();
  const navigate = useNavigate();

  useEffect(() => {
    if (!user || user.type !== expectedType) {
      navigate(ROUTE_PATH.HOME);
    }
  }, [user, expectedType, navigate]);

  return user && user.type === expectedType ? children : null;
}
```
- 적용
```typescript
export const router = createBrowserRouter([
  {
    {
      path: ROUTE_PATH.EMPLOYEE.EMPLOYEE_PAGE,
      element: (
        <RequireAuth expectedType="employee">
          <EmployeeMyPage />
        </RequireAuth>
      )
    },
    {
      path: ROUTE_PATH.MY_PAGE.EMPLOYER,
      element: (
        <RequireAuth expectedType="employer">
          <EmployerMyPage />
        </RequireAuth>
      )
    },
  },
]);
```