### PR TITLE
Refactor/#106 타입 수정 및 사인 등록 페이지 타이틀 추가

### DIFF
--- a/src/assets/translator/registerSign/registerSignData.ts
+++ b/src/assets/translator/registerSign/registerSignData.ts
@@ -1,6 +1,6 @@
 import { Languages } from '../Languages';
 
 export const registerSignData = {
-  [Languages.KO]: { registerSign: '사인 등록하기', reset: '초기화' },
-  [Languages.VE]: { registerSign: 'Đăng ký chữ ký', reset: 'Đặt lại' },
+  [Languages.KO]: { title: '사인 등록', registerSign: '사인 등록하기', reset: '초기화' },
+  [Languages.VE]: { title: 'Đăng ký chữ ký', registerSign: 'Đăng ký chữ ký', reset: 'Đặt lại' },
 };

--- a/src/pages/recruit/RecruitCard.tsx
+++ b/src/pages/recruit/RecruitCard.tsx
@@ -63,7 +63,7 @@ export default function RecruitCard({
 
   return (
     <RecruitContainer>
-      <CompanyImg alt="companyImg" src={imageUrl} />
+      {imageUrl ? <CompanyImg alt="companyImg" src={imageUrl} /> : <SkeletonImg />}
       <Info_Div>
         <Info_p>
           <p>{koreanTitle}</p>
@@ -125,7 +125,7 @@ const CompanyImg = styled.img<React.ImgHTMLAttributes<HTMLImageElement>>`
 
   border-radius: 20px;
   object-fit: cover;
-
+  display: ${(props) => (props.src ? 'block' : 'none')};
   @media (max-width: 768px) {
     height: 300px;
   }
@@ -187,5 +187,30 @@ const CustomBtn = styled(Button)<{ background?: string; color?: string; width?: 
 
   @media (max-width: 768px) {
     width: ${(props) => props.width || '160px'};
+  }
+`;
+
+const SkeletonImg = styled.div`
+  width: 100%;
+  height: 380px;
+  border-radius: 20px;
+  background: linear-gradient(90deg, #e0e0e0 25%, #f5f5f5 50%, #e0e0e0 75%);
+  background-size: 300% 100%;
+  animation: shimmer 5s infinite linear;
+
+  @media (max-width: 768px) {
+    height: 300px;
+  }
+  @media (max-width: 480px) {
+    height: 220px;
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: -300% 0;
+    }
+    100% {
+      background-position: 300% 0;
+    }
   }
 `;

--- a/src/pages/recruit/RecruitCard.tsx
+++ b/src/pages/recruit/RecruitCard.tsx
@@ -9,7 +9,7 @@ import { userLocalStorage } from '@/utils/storage';
 
 export default function RecruitCard({
   koreanTitle,
-  companyScale,
+  companySize,
   area,
   requestedCareer,
   imageUrl,
@@ -67,7 +67,7 @@ export default function RecruitCard({
       <Info_Div>
         <Info_p>
           <p>{koreanTitle}</p>
-          <p>{`${companyScale} | ${area} | ${requestedCareer}`}</p>
+          <p>{`${companySize} | ${area} | ${requestedCareer}`}</p>
         </Info_p>
         <Info_Btn>
           <CustomBtn

--- a/src/pages/recruit/RecruitType.ts
+++ b/src/pages/recruit/RecruitType.ts
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 export interface RecruitCardProps {
   koreanTitle: string;
   vietnameseTitle?: string;
-  companyScale: string;
+  companySize: string;
   area: string;
   requestedCareer: string;
   imageUrl: string;

--- a/src/pages/recruit/stories/RecruitCard.stories.tsx
+++ b/src/pages/recruit/stories/RecruitCard.stories.tsx
@@ -9,14 +9,14 @@ const meta: Meta<RecruitCardProps> = {
   tags: ['autodocs'],
   argTypes: {
     koreanTitle: { control: 'text' },
-    companyScale: { control: 'text' },
+    companySize: { control: 'text' },
     area: { control: 'text' },
     requestedCareer: { control: 'text' },
     imageUrl: { control: 'text' },
   },
   args: {
     koreanTitle: '김밥천국 채용 (1년 계약직)',
-    companyScale: '대기업',
+    companySize: '대기업',
     area: '대구 달서구',
     requestedCareer: '경력 1~2년',
     imageUrl: cat,

--- a/src/pages/registerSign/RegisterSign.tsx
+++ b/src/pages/registerSign/RegisterSign.tsx
@@ -8,6 +8,7 @@ import { Flex, Button } from '@/components/common';
 import { FetchRegisterSign } from '@/apis/registerSign/useRegisterSign';
 import { useTranslation } from 'react-i18next';
 import { userLocalStorage } from '@/utils/storage';
+import Title from '@/components/common/Title';
 
 export default function RegisterSign() {
   const userType = userLocalStorage.getUser()?.type || '';
@@ -42,6 +43,8 @@ export default function RegisterSign() {
         alignItems="center"
         gap={{ y: '20px' }}
       >
+        <Title text={t('registerSign.title')} />
+
         <WrapperCanvas>
           <SignatureCanvas
             ref={signCanvas}


### PR DESCRIPTION
## Issue
> #131 

## Description

### RecruitCardProps 타입 변경

> `companyScale` -> `companySize`로 변경했습니다.

### 사인 등록 컴포넌트 타이틀 추가 

![사인등록](https://github.com/user-attachments/assets/53b237f9-acec-4fae-910a-1ce5f00f361c)

> 공통 컴포넌트 `Title` 를 활용해서 제목을 추가했습니다.

### recruitCard 스켈레톤 이미지 추가
![img](https://github.com/user-attachments/assets/e1b109ce-4eb1-44a4-a894-c3bb58eb5e77)

> 이미지를 받아오기 전까지 스켈레톤 이미지가 렌더링 되게 했습니다.