### PR TITLE
Fix: 근로자 마이페이지 버튼 API 연결

### DIFF
--- a/src/apis/employee/mock/myApplicationList.mock.ts
+++ b/src/apis/employee/mock/myApplicationList.mock.ts
@@ -7,7 +7,7 @@ export const myApplicationList: MyRecruitListProps[] = [
       'https://img.freepik.com/free-photo/low-angle-view-of-skyscrapers_1359-1105.jpg?size=626&ext=jpg&ga=GA1.1.1297763733.1727740800&semt=ais_hybrid',
     title: '제목',
     area: '대전광역시 유성구',
-    state: 'LetsSign',
+    state: 'SIGNING_EMPLOYMENT_CONTRACT',
     applyId: 1,
   },
   {
@@ -16,7 +16,7 @@ export const myApplicationList: MyRecruitListProps[] = [
       'https://img.freepik.com/free-photo/low-angle-view-of-skyscrapers_1359-1105.jpg?size=626&ext=jpg&ga=GA1.1.1297763733.1727740800&semt=ais_hybrid',
     title: '제목2',
     area: '대전광역시 유성구',
-    state: 'Closed',
+    state: 'HIRING_CLOSED',
     applyId: 2,
   },
   {
@@ -25,7 +25,7 @@ export const myApplicationList: MyRecruitListProps[] = [
       'https://img.freepik.com/free-photo/low-angle-view-of-skyscrapers_1359-1105.jpg?size=626&ext=jpg&ga=GA1.1.1297763733.1727740800&semt=ais_hybrid',
     title: '제목3',
     area: '대전광역시 유성구',
-    state: 'Waiting',
+    state: 'REVIEWING_APPLICATION',
     applyId: 3,
   },
   {
@@ -34,7 +34,7 @@ export const myApplicationList: MyRecruitListProps[] = [
       'https://img.freepik.com/free-photo/low-angle-view-of-skyscrapers_1359-1105.jpg?size=626&ext=jpg&ga=GA1.1.1297763733.1727740800&semt=ais_hybrid',
     title: '제목4',
     area: '대전광역시 유성구',
-    state: 'Completed',
+    state: 'HIRED',
     applyId: 4,
   },
 ];

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -43,6 +43,7 @@ const Wrapper = styled.button<Props>(
 
     if (design === 'deactivate') {
       return {
+        cursor: 'default',
         color: '#9A9A9A',
         backgroundColor: '#D9D9D9',
       };

--- a/src/features/employee/myPage/MyRecruitCard.tsx
+++ b/src/features/employee/myPage/MyRecruitCard.tsx
@@ -4,21 +4,27 @@ import { MyRecruitListProps, StateProps, TextProps } from '@/types';
 import { useNavigate } from 'react-router-dom';
 import ROUTE_PATH from '@/routes/path';
 import { useGetContractImg } from '@/apis/contract/hooks/useGetContractImg';
+import React from 'react';
 
 type DesignProps = {
   design: 'default' | 'outlined' | 'textbutton' | 'deactivate';
   text?: TextProps;
+  style?: React.CSSProperties;
 };
 
 function getStateStyle(state: StateProps): DesignProps {
   switch (state) {
-    case 'LetsSign':
+    case 'SIGNING_EMPLOYMENT_CONTRACT':
       return { design: 'default', text: '근로계약서 서명하기' };
-    case 'Closed':
+    case 'HIRING_CLOSED':
       return { design: 'deactivate', text: '채용 마감' };
-    case 'Waiting':
-      return { design: 'outlined', text: '지원서 검토중' };
-    case 'Completed':
+    case 'REVIEWING_APPLICATION':
+      return {
+        design: 'deactivate',
+        text: '지원서 검토중',
+        style: { backgroundColor: '#fff', border: '3px solid #9A9A9A' },
+      };
+    case 'HIRED':
       return { design: 'outlined', text: '근로계약서 다운로드' };
     default:
       return { design: 'deactivate' }; // 상태가 정의되지 않은 경우
@@ -79,11 +85,11 @@ export default function MyRecruitCard({ myRecruit }: Props) {
       </TextSection>
       <Button
         design={buttonStyle.design}
-        style={{ width: '200px', padding: '10px 20px' }}
+        style={{ width: '200px', padding: '10px 20px', ...buttonStyle.style }}
         onClick={() => {
-          if (state == 'LetsSign') {
+          if (state == 'SIGNING_EMPLOYMENT_CONTRACT') {
             navigate(ROUTE_PATH.CONTRACT.EMPLOYEE.replace(':applyId', applyId.toString()));
-          } else if (state == 'Completed') {
+          } else if (state == 'HIRED') {
             downloadContract();
           }
         }}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -30,10 +30,10 @@ export type UserData = {
 
 // 백엔드에서 정하는 값에 따라 key 바꾸면 됨
 export const State = {
-  LetsSign: '근로계약서 서명하기',
-  Closed: '채용 마감',
-  Waiting: '지원서 검토중',
-  Completed: '근로계약서 다운로드',
+  SIGNING_EMPLOYMENT_CONTRACT: '근로계약서 서명하기',
+  HIRING_CLOSED: '채용 마감',
+  REVIEWING_APPLICATION: '지원서 검토중',
+  HIRED: '근로계약서 다운로드',
 } as const;
 
 export type StateProps = keyof typeof State;


### PR DESCRIPTION
## Description
백엔드 측에서 정해준 키워드로 근로자 마이페이지 버튼 상태 구분하는 키워드 변경 완료했습니다.
```typescript
export const State = {
  SIGNING_EMPLOYMENT_CONTRACT: '근로계약서 서명하기',
  HIRING_CLOSED: '채용 마감',
  REVIEWING_APPLICATION: '지원서 검토중',
  HIRED: '근로계약서 다운로드',
} as const;
```
![image](https://github.com/user-attachments/assets/71c91c7c-cd21-4a3e-9cea-423b498aaac2)
