### PR TITLE
Fix/#144 지원자 목록 페이지 한국어 실력 표시 누락 문제 해결

### DIFF
--- a/src/apis/applicants/mocks/applicants.mock.ts
+++ b/src/apis/applicants/mocks/applicants.mock.ts
@@ -19,7 +19,7 @@ export const applicantList = [
     resumeId: 1,
     applyId: 1,
     applicantNation: '베트남',
-    korean: '중급',
+    koreanLanguageLevel: '중급',
   },
   {
     userId: 2,
@@ -27,6 +27,6 @@ export const applicantList = [
     resumeId: 2,
     applyId: 2,
     applicantNation: '베트남',
-    korean: '고급',
+    koreanLanguageLevel: '고급',
   },
 ];

--- a/src/pages/applicantsPage/ApplicantList/ApplicantsTable.tsx
+++ b/src/pages/applicantsPage/ApplicantList/ApplicantsTable.tsx
@@ -57,7 +57,7 @@ export default function ApplicantsTable({ applicantList }: Props) {
               <tr key={applicant.applyId}>
                 <Td>{applicant.name}</Td>
                 <Td>{applicant.applicantNation}</Td>
-                <Td>{applicant.korean}</Td>
+                <Td>{applicant.koreanLanguageLevel}</Td>
                 <Td css={buttonsCellStyle}>
                   <Flex justifyContent="flex-end" alignItems="center" gap={{ x: '20px' }} css={buttonGroupStyle}>
                     <Button

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -13,7 +13,7 @@ export type ApplicantData = {
   resumeId: number;
   applyId: number;
   applicantNation: string;
-  korean: string;
+  koreanLanguageLevel: string;
 };
 
 export type ForeignerData = {


### PR DESCRIPTION
## Issue
> #144 

## Description
### 지원자의 한국어 실력
- 필드명을 `koreanLanguageLevel`로 올바르게 수정하여 해결했습니다.
```typescript
export type ApplicantData = {
  userId: number;
  name: string;
  resumeId: number;
  applyId: number;
  applicantNation: string;
  koreanLanguageLevel: string;
};
```

### ScreenShots
<img src="https://github.com/user-attachments/assets/e11cd977-fbe2-4da0-aa76-bfdcce415d72" width="700px" />