### PR TITLE
Feat/#142 회사등록 및 근로계약서 API 연결 완료

### DIFF
--- a/src/apis/contract/hooks/usePostEmployeeSign.tsx
+++ b/src/apis/contract/hooks/usePostEmployeeSign.tsx
@@ -13,7 +13,7 @@ export const postSignEmployeeContract = async (req: SignEmployeeContractRequestD
   return response.data;
 };
 
-export const useFetchPostContract = () =>
+export const usePostSignEmployeeContract = () =>
   useMutation({
     mutationFn: postSignEmployeeContract,
   });

--- a/src/pages/contract/EmployeeContract/EmployeeContract.tsx
+++ b/src/pages/contract/EmployeeContract/EmployeeContract.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { useGetMyContract } from '@/apis/contract/hooks/useGetMyContract';
-import { useFetchPostContract } from '@/apis/contract/hooks/usePostContract';
 import { Button, Flex, Typo } from '@/components/common';
 import Layout from '@/features/layout';
 import ROUTE_PATH from '@/routes/path';
 import styled from '@emotion/styled';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
+import { usePostSignEmployeeContract } from '@/apis/contract/hooks/usePostEmployeeSign';
 
 export type ContractResponseData = {
   salary: string;
@@ -23,7 +23,7 @@ export default function EmployeeContract() {
   const { applyId } = useParams();
   const applicationId = Number(applyId);
   const { data: contract } = useGetMyContract(applicationId);
-  const mutation = useFetchPostContract();
+  const mutation = usePostSignEmployeeContract();
   const navigate = useNavigate();
   const contractData: ContractResponseData = contract || {};
 

--- a/src/pages/registerCompany/RegisterCompany.tsx
+++ b/src/pages/registerCompany/RegisterCompany.tsx
@@ -90,8 +90,6 @@ export default function RegisterCompany() {
 
     if (file) {
       formData.append('logoImage', file);
-    } else {
-      formData.append('logoImage', '');
     }
 
     mutation.mutate(formData, {


### PR DESCRIPTION
## Issue
> close #142 

## Description
### 회사등록 API 연결 완료
- 로고 이미지 입력이 선택으로 바뀌어, 이미지를 입력받지 않는 경우 백엔드 서버에 전달하는 formData에 logoImage를 넣지 않고 전달합니다.
```javascript
    if (file) {
      formData.append('logoImage', file);
(-)  } else {
(-)     formData.append('logoImage', '');
    }
```

### 근로계약서 API 연결 완료
- 고용주의 근로계약서 등록 API 연결이 완료되었습니다.(usePostContract)
- 근로자의 근로계약서 확인 API 연결이 완료되었습니다.(useGetMyContract)
- 근로자의 근로계약서 등록 API 연결이 완료되었습니다.(usePostEmployeeSign)
- 근로자의 근로계약서 다운로드 API 연결이 완료되었습니다.(useGetContractImg)
- 근로계약서 다운로드는 지원글 목록에서 "채용완료" 단계의 버튼 상태일 때 가능합니다.
![image](https://github.com/user-attachments/assets/0cb792b7-75e9-4507-b9b5-8ca43bb28b35)

